### PR TITLE
Fix imports and database URL handling

### DIFF
--- a/src/api/v1/endpoints/auth.py
+++ b/src/api/v1/endpoints/auth.py
@@ -6,8 +6,7 @@ from sqlalchemy.orm import Session
 from src.config import settings
 from src.database import get_db
 from src.models.user import User
-from src.schemas.auth import Token, TokenPayload
-from src.schemas.user import UserCreate, UserResponse
+from src.schemas.user import Token, TokenPayload, UserCreate, UserResponse
 from src.security import (
     verify_password,
     get_password_hash,

--- a/src/database.py
+++ b/src/database.py
@@ -7,7 +7,7 @@ from src.config import settings
 
 # Create SQLAlchemy engine
 engine = create_engine(
-    settings.DATABASE_URL,
+    str(settings.DATABASE_URL),
     poolclass=QueuePool,
     pool_size=5,
     max_overflow=10,

--- a/src/schemas/user.py
+++ b/src/schemas/user.py
@@ -30,6 +30,9 @@ class UserInDBBase(UserBase):
 class User(UserInDBBase):
     pass
 
+class UserResponse(UserInDBBase):
+    pass
+
 class UserInDB(UserInDBBase):
     hashed_password: str
 

--- a/src/security.py
+++ b/src/security.py
@@ -67,6 +67,13 @@ async def get_current_active_user(
         raise HTTPException(status_code=400, detail="Inactive user")
     return current_user
 
+async def get_current_superuser(
+    current_user: User = Depends(get_current_user)
+) -> User:
+    if not current_user.is_superuser:
+        raise HTTPException(status_code=400, detail="Not enough privileges")
+    return current_user
+
 def verify_token(token: str) -> dict:
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"])


### PR DESCRIPTION
## Summary
- fix auth module imports to use user schemas
- cast DATABASE_URL to str when creating SQLAlchemy engine
- add UserResponse schema
- implement get_current_superuser helper

## Testing
- `PYTHONPATH=.:src pytest -q` *(fails: ModuleNotFoundError: No module named 'distutils.filelist')*

------
https://chatgpt.com/codex/tasks/task_e_685119dc6904832e90bc0c5b8b619a03