### PR TITLE
Update OpenTelemetry versions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -49,10 +49,10 @@ asyncpg==0.29.0
 
 # Monitoring and Logging
 prometheus-client==0.19.0
-opentelemetry-api==1.22.0
-opentelemetry-sdk==1.22.0
-opentelemetry-instrumentation-fastapi==0.42b0
-opentelemetry-exporter-otlp==1.22.0
+opentelemetry-api==1.34.1
+opentelemetry-sdk==1.34.1
+opentelemetry-instrumentation-fastapi==0.55b1
+opentelemetry-exporter-otlp==1.34.1
 structlog==24.1.0
 
 # Security

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,10 +20,10 @@ aioredis==2.0.1
 
 # Monitoring
 prometheus-client==0.19.0
-opentelemetry-api==1.23.0
-opentelemetry-sdk==1.23.0
-opentelemetry-instrumentation-fastapi==0.44b0
-opentelemetry-exporter-otlp==1.23.0
+opentelemetry-api==1.34.1
+opentelemetry-sdk==1.34.1
+opentelemetry-instrumentation-fastapi==0.55b1
+opentelemetry-exporter-otlp==1.34.1
 
 # Testing
 pytest==8.0.1


### PR DESCRIPTION
## Summary
- bump OpenTelemetry packages to latest versions

## Testing
- `pytest tests/ -v --cov=src --cov-report=term-missing` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6851b9466de4832ebc373d5234841bd3