### PR TITLE
Update type stub dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,10 +18,10 @@ pylint==3.0.3
 bandit==1.7.7
 
 # Type Checking
-types-all==1.0.0
 types-requests==2.31.0.20240125
 types-PyYAML==6.0.12.12
 types-python-dateutil==2.8.19.20240106
+types-setuptools==69.0.0.20240106
 
 # Documentation
 mkdocs==1.5.3


### PR DESCRIPTION
## Summary
- replace `types-all` with specific stubs and add `types-setuptools`
- remove stray type stub reference

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6851c1d6e474832ead3acaccd177c6b7