### PR TITLE
Add httpx version fix script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ opentelemetry-exporter-otlp==1.34.1
 pytest>=8.0.0
 pytest-asyncio==0.23.5
 pytest-cov>=4.1.0
-httpx==0.26.0
+httpx>=0.28.1,<1.0.0
 
 # Development
 black>=24.1.1

--- a/update_httpx.py
+++ b/update_httpx.py
@@ -1,0 +1,44 @@
+import re
+import subprocess
+from pathlib import Path
+
+REQ_FILE = Path('requirements.txt')
+HTTPX_CONFLICT_VERSION = '0.26.0'
+HTTPX_FIXED_RANGE = '>=0.28.1,<1.0.0'
+
+def main():
+    if not REQ_FILE.exists():
+        print('requirements.txt not found.')
+        return
+
+    lines = REQ_FILE.read_text().splitlines()
+    httpx_idx = None
+    autogen_present = any('autogen' in line and not line.strip().startswith('#') for line in lines)
+
+    for i, line in enumerate(lines):
+        if line.strip().startswith('httpx=='):
+            httpx_idx = i
+            break
+
+    if httpx_idx is not None:
+        version = lines[httpx_idx].split('==')[1]
+        if version == HTTPX_CONFLICT_VERSION and autogen_present:
+            print(
+                f'Warning: httpx=={HTTPX_CONFLICT_VERSION} conflicts with autogen. '
+                f'Updating to httpx{HTTPX_FIXED_RANGE}.'
+            )
+            lines[httpx_idx] = f'httpx{HTTPX_FIXED_RANGE}'
+            REQ_FILE.write_text('\n'.join(lines) + '\n')
+        else:
+            print('No conflicting httpx version found.')
+    else:
+        print('httpx not pinned, nothing to update.')
+
+    # Bonus: install packages
+    try:
+        subprocess.run(['pip', 'install', '-r', str(REQ_FILE)], check=True)
+    except subprocess.CalledProcessError as exc:
+        print('pip install failed:', exc)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add script `update_httpx.py` to detect autogen/httpx conflicts
- update `requirements.txt` to use compatible `httpx` version

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `python update_httpx.py` *(runs until interrupted during pip install)*

------
https://chatgpt.com/codex/tasks/task_e_685244f15c54832e8fb2bc06f940d4d7