### PR TITLE
Fix mkdocs autorefs config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,8 @@ markdown_extensions:
 
 plugins:
   - search
+  - autorefs:
+      link_titles: auto
   - mkdocstrings:
       default_handler: python
       handlers:


### PR DESCRIPTION
## Summary
- add mkdocs-autorefs plugin with link_titles config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685259a02edc832e91a9c21713743d37