### PR TITLE
Add PostgreSQL retry script

### DIFF
--- a/connect_with_retry.py
+++ b/connect_with_retry.py
@@ -1,0 +1,31 @@
+import time
+
+import psycopg2
+from psycopg2 import OperationalError
+
+MAX_RETRIES = 5
+RETRY_DELAY = 2  # seconds
+
+
+def connect_with_retry():
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            conn = psycopg2.connect(
+                dbname="test_db",
+                user="postgres",
+                password="postgres",
+                host="postgres",
+                port=5432,
+            )
+            print("Database connection established.")
+            conn.close()
+            return
+        except OperationalError as exc:
+            print(f"Attempt {attempt} failed: {exc}")
+            if attempt == MAX_RETRIES:
+                raise
+            time.sleep(RETRY_DELAY)
+
+
+if __name__ == "__main__":
+    connect_with_retry()


### PR DESCRIPTION
## Summary
- add simple postgres connection script with retry logic

## Testing
- `isort --check --diff connect_with_retry.py`
- `flake8 connect_with_retry.py`
- `python -m py_compile connect_with_retry.py`
- `pytest -k 'this_test_does_not_exist' -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685260513fe8832e92f28236a9308c55