### PR TITLE
Fix import formatting with isort/black

### DIFF
--- a/src/explainability/explainability_service.py
+++ b/src/explainability/explainability_service.py
@@ -12,6 +12,7 @@ import seaborn as sns
 import shap
 import torch
 import torch.nn as nn
+from captum.attr import IntegratedGradients
 from fastapi import FastAPI, HTTPException
 from mlflow.tracking import MlflowClient
 from prometheus_client import Counter, Gauge, Histogram
@@ -19,7 +20,6 @@ from pydantic import BaseModel
 from ray import serve
 from ray.serve.config import HTTPOptions
 from transformers import AutoModelForCausalLM
-from captum.attr import IntegratedGradients
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)

--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from prometheus_client import make_asgi_app
 
+from src.api.v1.endpoints import auth, avatar, users
 from src.config import settings
 from src.database import init_db
 from src.logger import logger
@@ -15,7 +16,6 @@ from src.monitoring import (
     setup_tracing,
 )
 from src.security import rate_limit_middleware
-from src.api.v1.endpoints import auth, avatar, users
 
 # Create FastAPI app
 app = FastAPI(

--- a/src/security.py
+++ b/src/security.py
@@ -1,14 +1,14 @@
+import time
+from collections import defaultdict
 from datetime import datetime, timedelta
 from typing import Optional
 
-from fastapi import Depends, HTTPException, status, Request
+from fastapi import Depends, HTTPException, Request, status
+from fastapi.responses import JSONResponse
 from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt
 from passlib.context import CryptContext
 from sqlalchemy.orm import Session
-from collections import defaultdict
-import time
-from fastapi.responses import JSONResponse
 
 from src.config import settings
 from src.database import get_db

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,8 @@
 from unittest.mock import patch
+
 import pytest
 from fastapi.testclient import TestClient
+
 from sentient_avatar.avatar_server import app
 from sentient_avatar.config.config import Config, get_default_config
 from sentient_avatar.services.factory import ServiceFactory


### PR DESCRIPTION
## Summary
- fix import grouping order in `security.py`
- fix import grouping order in `main.py`
- fix import grouping order in `explainability_service.py`
- fix import grouping order in `tests/test_integration.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6853950b16c0832eaa287a25052c60ee