### PR TITLE
Fix imports and PostgreSQL setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,10 @@ cp .env.example .env
 # PostgreSQL and Redis instance. Ensure the `POSTGRES_USER` in `.env` refers to
 # an existing database role. The provided `.env.example` sets this to `postgres`.
 # Using an invalid role such as `root` will prevent the application from connecting.
-# are unavailable the application will start with database initialization errors
-# logged but will continue running.
+# If the role specified in `POSTGRES_USER` does not exist, create it first:
+# `createuser -s $POSTGRES_USER`.
+# When the database or Redis services are unavailable the application will start
+# with database initialization errors logged but will continue running.
 
 # Initialize database
 alembic upgrade head

--- a/connect_with_retry.py
+++ b/connect_with_retry.py
@@ -7,9 +7,27 @@ MAX_RETRIES = 5
 RETRY_DELAY = 2  # seconds
 
 
-def connect_with_retry():
+def connect_with_retry() -> None:
+    """Attempt to connect to PostgreSQL, creating the role if necessary."""
     for attempt in range(1, MAX_RETRIES + 1):
         try:
+            conn = psycopg2.connect(
+                dbname="postgres",
+                user="postgres",
+                password="postgres",
+                host="postgres",
+                port=5432,
+            )
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute("SELECT 1 FROM pg_roles WHERE rolname=%s", ("postgres",))
+                if cur.fetchone() is None:
+                    cur.execute("CREATE ROLE postgres LOGIN SUPERUSER PASSWORD %s", ("postgres",))
+                cur.execute("SELECT 1 FROM pg_database WHERE datname=%s", ("test_db",))
+                if cur.fetchone() is None:
+                    cur.execute("CREATE DATABASE test_db OWNER postgres")
+            conn.close()
+
             conn = psycopg2.connect(
                 dbname="test_db",
                 user="postgres",

--- a/src/avatar/avatar_service.py
+++ b/src/avatar/avatar_service.py
@@ -1615,10 +1615,11 @@ class AvatarService:
                 await websocket.close()
 
         @self.app.post("/avatar/expression")
-        async def update_expression(request: AvatarRequest):
+        async def update_expression(request: AvatarRequest) -> dict[str, Any]:
             try:
                 # Process frame
-                frame = self._decode_frame(request.frame)
+                frame_bytes = request.frame.encode()
+                frame = self._decode_frame(frame_bytes)
                 start_time = time.time()
                 avatar_frame = await self.renderer.process_frame(
                     frame, confidence=request.confidence

--- a/src/monitoring/__init__.py
+++ b/src/monitoring/__init__.py
@@ -1,0 +1,25 @@
+"""Monitoring metrics and setup utilities."""
+
+from ..monitoring import (
+    REQUEST_COUNT,
+    REQUEST_LATENCY,
+    ACTIVE_REQUESTS,
+    AVATAR_CREATIONS,
+    AVATAR_UPDATES,
+    EMOTION_CHANGES,
+    COGNITIVE_PROCESSING_TIME,
+    PHYSICAL_ACTION_TIME,
+    setup_tracing,
+)
+
+__all__ = [
+    "REQUEST_COUNT",
+    "REQUEST_LATENCY",
+    "ACTIVE_REQUESTS",
+    "AVATAR_CREATIONS",
+    "AVATAR_UPDATES",
+    "EMOTION_CHANGES",
+    "COGNITIVE_PROCESSING_TIME",
+    "PHYSICAL_ACTION_TIME",
+    "setup_tracing",
+]

--- a/src/security/__init__.py
+++ b/src/security/__init__.py
@@ -1,0 +1,25 @@
+"""Security utilities exposed for API modules."""
+
+from ..security import (
+    create_access_token,
+    create_refresh_token,
+    get_current_user,
+    get_current_active_user,
+    get_current_superuser,
+    get_password_hash,
+    verify_password,
+    verify_token,
+    oauth2_scheme,
+)
+
+__all__ = [
+    "create_access_token",
+    "create_refresh_token",
+    "get_current_user",
+    "get_current_active_user",
+    "get_current_superuser",
+    "get_password_hash",
+    "verify_password",
+    "verify_token",
+    "oauth2_scheme",
+]


### PR DESCRIPTION
## Summary
- expose auth helpers and monitoring metrics via package `__init__` files
- decode avatar frames from bytes
- create missing PostgreSQL role and DB if needed
- clarify role creation in README

## Testing
- `python -m py_compile connect_with_retry.py src/security/__init__.py src/monitoring/__init__.py src/avatar/avatar_service.py`

------
https://chatgpt.com/codex/tasks/task_e_6854d5112a7c832e87c00c252f8071de